### PR TITLE
Fix typo in overlay-text.

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
         </div>
         <div id="chartOverlay" class="overlay">
           <div class="overlay-text">
-            Pick your options at the bottom fo the page,<br />
+            Pick your options at the bottom of the page,<br />
             then hit <b>Submit</b> to continue.
           </div>
         </div>


### PR DESCRIPTION
Browsing your Runedata v2 and found a (very minor) typo in the overlay-text of index.html.  
